### PR TITLE
Fixes on ChatHandler and Flashlight sync

### DIFF
--- a/OuterWildsOnline/ConnectionController.cs
+++ b/OuterWildsOnline/ConnectionController.cs
@@ -353,7 +353,7 @@ namespace OuterWildsOnline
 
             SFSSectorManager.RefreshSectors();
 
-            gameObject.AddComponent<ChatHandler>();
+            new GameObject("ChatHandler").AddComponent<ChatHandler>();
 
             StopAllCoroutines();
             StartCoroutine(GetClosestSectorToPlayer(2f));
@@ -371,7 +371,6 @@ namespace OuterWildsOnline
             Connection.Send(new ExtensionRequest("GeneralEvent", data, Connection.LastJoinedRoom));
             Instance.StartCoroutine(Instance.Disconnect(0.1f));
             //TODO fazer com que ele não disconecte quando ir para o menu principal
-            Destroy(Instance.GetComponent<ChatHandler>());
         }
         public IEnumerator Disconnect(float delay)
         {

--- a/OuterWildsOnline/StaticClasses/CreateRemoteCopies.cs
+++ b/OuterWildsOnline/StaticClasses/CreateRemoteCopies.cs
@@ -3,7 +3,6 @@ using UnityEngine;
 
 namespace OuterWildsOnline
 {
-    //TODO consertar isso
     public static class CreateRemoteCopies
     {
         private static void FindAndDoAction(Transform parentTransform, Action<Transform> action, bool ignoreIfNotFound, params string[] childNames) 
@@ -139,7 +138,6 @@ namespace OuterWildsOnline
             //remotePlayer.AddComponent<LockOnReticule>().Init();
             return remotePlayer;
         }
-        //TODO fazer com que não fique tão confuso com a quantidade de strings espalhadas
         public static GameObject CreateShipRemoteCopy()
         {
             GameObject remotePlayerShip = new GameObject("Remote Ship");
@@ -264,6 +262,22 @@ namespace OuterWildsOnline
             remoteProbe.SetActive(false);
             remoteProbeBody.SetActive(false);
             return remoteProbe;
+        }
+        //Raft_Body
+        //Disable:
+        //Detector_Raft
+        //LightSensorRoot
+        //Colliders
+        //PushInteractCollider
+        //RideVolume
+        //Sync:
+        //ChurnParticles (Particles)
+        //ImpactAudio (Audio)
+        //MovementAudio (Audio)
+        public static GameObject CreateRaftRemoteCopy() 
+        {
+
+            return null;
         }
     }
 }

--- a/OuterWildsOnline/SyncObjects/GameObjectsToReceiveSync/PlayerToReceiveSync.cs
+++ b/OuterWildsOnline/SyncObjects/GameObjectsToReceiveSync/PlayerToReceiveSync.cs
@@ -71,12 +71,13 @@ namespace OuterWildsOnline.SyncObjects
 
             if (playerAnimationSync != null && playerStateSync != null)
             {
-                if (objectData.GetBool("suit"))
+                bool shouldBeWithSuit = objectData.GetBool("suit");
+                if (objectData.GetBool("suit") && !playerStateSync.IsWearingSuit())
                 {
                     playerAnimationSync.OnPutOnSuit();
                     playerStateSync.OnSuitUp();
                 }
-                else
+                else if(!shouldBeWithSuit && playerStateSync.IsWearingSuit())
                 {
                     playerAnimationSync.OnRemoveSuit();
                     playerStateSync.OnRemoveSuit();


### PR DESCRIPTION
* Made ChatHandler  its own gameobject that will get automatically destroyed on scene loads
* Fixed issue that would make the remote animations break when using the flashlight without having put the suit on for the first time
* Made some research for syncing rafts